### PR TITLE
Update miner setup instructions

### DIFF
--- a/web/templates/index.tmpl
+++ b/web/templates/index.tmpl
@@ -260,7 +260,7 @@
             <strong>Download and run miner</strong><br>
             <ul class="list-group">
               <li>Download miner <a target="_blank" href="https://github.com/PoC-Consortium/scavenger/releases/latest">Scavenger</a></li>
-              <li>Edit <strong>mining.conf</strong>: set <strong>poolUrl</strong> and <strong>miningInfoUrl</strong> to <strong>{{ .Cfg.PoolAddress }}:{{ .Cfg.PoolPort }}</strong></li>
+              <li>Edit <strong>config.yaml</strong>: set <strong>url</strong> to <strong style="white-space: nowrap;">http://{{ .Cfg.PoolAddress }}:{{ .Cfg.PoolPort }}</strong></li>
               <li>Run miner</li>
             </ul>
           </div>


### PR DESCRIPTION
changed from miner.conf (blago) to config.yaml (scavenger) and amended instruction. Made the url string non-breaking to ease copy-pasting of the url.